### PR TITLE
Category Mapping 오류로 인한 재지정

### DIFF
--- a/backend/src/main/kotlin/com/study/commerce/product/domain/Category.kt
+++ b/backend/src/main/kotlin/com/study/commerce/product/domain/Category.kt
@@ -9,6 +9,6 @@ class Category(
     @Column(name ="category_id")
     val categoryId: Long? = null,
 
-    @OneToMany(mappedBy = "Category")
+    @OneToMany(mappedBy = "category")
     val categoryItem: List<CategoryItem>
 )

--- a/backend/src/main/kotlin/com/study/commerce/product/domain/CategoryItem.kt
+++ b/backend/src/main/kotlin/com/study/commerce/product/domain/CategoryItem.kt
@@ -15,5 +15,5 @@ class CategoryItem(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "categoryId")
-    var categoryId: Category
+    var category: Category
 )


### PR DESCRIPTION
Category Mapping 재지정하여 PR요청합니다.

mappedBy에는 연관 관계의 주인이 아니란 뜻으로, 반대 방향의 필드 이름이 와야합니다.

* 일반적으로 연관 관계의 주인은 외래키를 가지고 있는쪽으로 지정합니다.
* 여기서 외래키는 'categoryId'이네요. (외래키 지정은 (@JoinColumn(name = "categoryId"))
* 참고 사이트 : https://kok202.tistory.com/138